### PR TITLE
fix: save space

### DIFF
--- a/report/src/generateUrlReport.js
+++ b/report/src/generateUrlReport.js
@@ -56,10 +56,7 @@ const zapCleanup = (result) =>
  * @returns {NucleiReport} minified JSON content
  */
 const nucleiCleanup = (result, url) =>
-  result &&
-  result.map &&
-  result
-    .map((r) => omit(r, ["request", "response"]))
+  result && result.map && result.map((r) => omit(r, ["request", "response"]));
 
 /**
  * Minify Lighthouse JSON data
@@ -111,8 +108,7 @@ const lhrCleanup = (result) => {
 /**
  * Minify wget spider report
  */
-const wget404Cleanup = (result) => result && result.broken
-
+const wget404Cleanup = (result) => result && result.broken;
 
 //@ts-expect-error
 const requireToolData = (filename) => (basePath) =>
@@ -150,17 +146,8 @@ const noop = (args) => args;
  */
 const generateUrlReport = (url) => {
   const urlb64 = Buffer.from(url.url).toString("base64");
-  const urlPath = path.join(DASHLORD_REPO_PATH, "results", urlb64);
-  if (fs.existsSync(urlPath)) {
-    // use filesystem to determine latest scan report
-    const scans = fs.readdirSync(urlPath);
-    scans.sort().reverse();
-    const lastScan = scans.length && scans[0];
-    if (!lastScan) {
-      return null;
-    }
-    const latestFilesPath = path.join(urlPath, lastScan);
-
+  const latestFilesPath = path.join(DASHLORD_REPO_PATH, "results", urlb64);
+  if (fs.existsSync(latestFilesPath)) {
     // compile all tools data
     /** @type {UrlReport} toolsData */
     //@ts-expect-error

--- a/report/src/generateUrlReport.js
+++ b/report/src/generateUrlReport.js
@@ -106,7 +106,13 @@ const lhrCleanup = (result) => {
 };
 
 /**
+ *
  * Minify wget spider report
+ *
+ * @param {{broken?:Wget404Report}} result Lighthouse JSON content
+ *
+ * @returns {Wget404Report|undefined} minified JSON content
+ *
  */
 const wget404Cleanup = (result) => result && result.broken;
 

--- a/report/src/generateUrlReport.test.js
+++ b/report/src/generateUrlReport.test.js
@@ -11,7 +11,7 @@ const b64 = "aHR0cHM6Ly93d3cudGVzdC5jb20=";
 // mock a json in the latest scan
 const mockJson = (name, data) =>
   jest.mock(
-    `results/${b64}/9876/${name}`,
+    `results/${b64}/${name}`,
     () =>
       data
         ? data
@@ -23,7 +23,7 @@ const mockJson = (name, data) =>
 
 // for some reason jest.resetModules doesnt work with virtual JSON mocks
 const unMockJson = (name) => {
-  jest.unmock(`results/${b64}/9876/${name}`);
+  jest.unmock(`results/${b64}/${name}`);
 };
 
 describe("generateUrlReport", () => {
@@ -42,22 +42,24 @@ describe("generateUrlReport", () => {
   test(`should generate latest report for a valid url`, () => {
     fs.existsSync.mockImplementationOnce(() => true); // check url folder
     fs.existsSync.mockImplementationOnce(() => false); // screenshot
-    fs.readdirSync.mockImplementationOnce(() => ["9876", "1234", "5678"]); // assume scans folders use a sortable date-format
 
     // mock all required files
-    mockJson("codescanalerts.json", {report: "codescanalerts.json", totalCount: 42});
-    mockJson("dependabotalerts.json", {report: "dependabotalerts.json"});
-    mockJson("http.json", {report: "http.json"});
-    mockJson("lhr.json", {report: "lhr.json"});
-    mockJson("nmapvuln.json", {report: "nmap.json"});
-    mockJson("nuclei.json", [{report: "nuclei.json"}]);
-    mockJson("testssl.json", [{report: "testssl.json"}]);
-    mockJson("thirdparties.json", {report: "thirdparties.json"});
-    mockJson("updownio.json", {report: "updownio.json"});
-    mockJson("wappalyzer.json", {report: "wappalyzer.json"});
-    mockJson("zap.json", {report: "zap.json"});
-    mockJson("stats.json", {report: "stats.json"});
-    mockJson("404.json", {broken: [1, 2, 3]});
+    mockJson("codescanalerts.json", {
+      report: "codescanalerts.json",
+      totalCount: 42,
+    });
+    mockJson("dependabotalerts.json", { report: "dependabotalerts.json" });
+    mockJson("http.json", { report: "http.json" });
+    mockJson("lhr.json", { report: "lhr.json" });
+    mockJson("nmapvuln.json", { report: "nmap.json" });
+    mockJson("nuclei.json", [{ report: "nuclei.json" }]);
+    mockJson("testssl.json", [{ report: "testssl.json" }]);
+    mockJson("thirdparties.json", { report: "thirdparties.json" });
+    mockJson("updownio.json", { report: "updownio.json" });
+    mockJson("wappalyzer.json", { report: "wappalyzer.json" });
+    mockJson("zap.json", { report: "zap.json" });
+    mockJson("stats.json", { report: "stats.json" });
+    mockJson("404.json", { broken: [1, 2, 3] });
 
     expect(
       generateUrlReport({
@@ -83,7 +85,6 @@ describe("generateUrlReport", () => {
   test(`should allow empty/invalid reports`, () => {
     fs.existsSync.mockImplementationOnce(() => true); // check url folder
     fs.existsSync.mockImplementationOnce(() => false); // screenshot
-    fs.readdirSync.mockImplementationOnce(() => ["9876", "1234", "5678"]); // assume scans folders use a sortable date-format
 
     mockJson("codescanalerts.json");
     mockJson("wappalyzer.json");
@@ -101,7 +102,6 @@ describe("generateUrlReport", () => {
   test(`should detect screenshot if any`, () => {
     fs.existsSync.mockImplementationOnce(() => true); // check url folder
     fs.existsSync.mockImplementationOnce(() => true); // screenshot
-    fs.readdirSync.mockImplementationOnce(() => ["9876", "1234", "5678"]); // assume scans folders use a sortable date-format
     expect(
       generateUrlReport({
         url: testUrl,

--- a/report/src/utils.js
+++ b/report/src/utils.js
@@ -63,6 +63,9 @@ const getConfig = () => {
   let dashlordConfig = {
     title: "DashLord report",
     urls: [],
+    entity: "",
+    footer: "",
+    description: "",
   };
 
   if (fs.existsSync(path.join(DASHLORD_REPO_PATH, "dashlord.yaml"))) {

--- a/report/www/src/components/404.tsx
+++ b/report/www/src/components/404.tsx
@@ -4,21 +4,14 @@ import { Table } from "@dataesr/react-dsfr";
 
 import { Panel } from "./Panel";
 
-type WappalyzerProps = { data: any };
+type Report404Props = { data: Wget404Report };
 
+const columns = [{ name: "link", label: "URL" }];
 
-const columns = [
-  { name: "link", label: "URL" }
-];
-
-export const Report404: React.FC<WappalyzerProps> = ({ data }) =>
+export const Report404: React.FC<Report404Props> = ({ data }) =>
   (data && data.length && (
     <Panel title="Erreurs 404" info="Pages introuvables">
-      <Table
-        rowKey="name"
-        columns={columns}
-        data={data}
-      />
+      <Table rowKey="name" columns={columns} data={data} />
     </Panel>
   )) ||
   null;

--- a/save/action.yml
+++ b/save/action.yml
@@ -16,14 +16,12 @@ runs:
         DASHLORD_REPO_PATH=${{ github.workspace }};
         # store results in a folder with then base64 encoded url
         URL_BASE64=$(printf "%s" "$URL" | base64 -w 500) # default is wrap at 76
-        NOW=$(date +"%Y%m%d_%H%M%S")
-        OUT_PATH="./results/${URL_BASE64}/${NOW}"
+        OUT_PATH="./results/${URL_BASE64}"
 
         echo "URL: $URL"
         echo "URL base 64: $URL_BASE64"
         echo "HOSTNAME: $HOSTNAME"
         echo "DASHLORD_REPO_PATH: $DASHLORD_REPO_PATH"
-        echo "NOW: $NOW"
         echo "OUT_PATH: $OUT_PATH"
 
         cd $DASHLORD_REPO_PATH
@@ -50,7 +48,6 @@ runs:
         mv scans/* $OUT_PATH/ || true
 
         mv report_json.json $OUT_PATH/zap.json || true
-        mv report_md.md $OUT_PATH/zap.md || true
         mv report_html.html $OUT_PATH/zap.html || true
 
         ###### put screenshot if any ######
@@ -73,4 +70,3 @@ runs:
                 mv .lighthouseci/lhr-${LHR_TIMESTAMP}.html $OUT_PATH/lhr.html
             done
         fi
-      

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -328,6 +328,8 @@ type UpDownReport = {
   apdexGrade: string;
 };
 
+type Wget404Report = string[];
+
 type UrlReport = UrlConfig & {
   lhr?: LighthouseReport | null;
   testssl?: SslTestReport | null;
@@ -343,6 +345,7 @@ type UrlReport = UrlConfig & {
   screenshot?: boolean | null;
   summary: UrlReportSummary;
   stats?: StatsReport | null;
+  404?: Wget404Report | null;
 };
 
 type DashLordReport = UrlReport[];


### PR DESCRIPTION
a simple fix to limit disk space usage : always use the same folder to store scans artifacts for a given url
 - in `save` action : save in the same url folder
 - in `report` action : use the same url folder
