### PR TITLE
fix(report): Do not display 0 instead of blank 404 widget

### DIFF
--- a/report/www/src/components/Url.tsx
+++ b/report/www/src/components/Url.tsx
@@ -59,8 +59,7 @@ const tabs = [
       },
       {
         id: "404",
-        render: (report, url) =>
-          report["404"].length && <Report404 data={report["404"]} />,
+        render: (report, url) => <Report404 data={report["404"]} />,
       },
     ],
   },


### PR DESCRIPTION
En regardant le détail du report pour une application sur laquelle je travaille, j'ai remarqué un 0 en bas de page :

<img width="1218" alt="image" src="https://user-images.githubusercontent.com/2291025/154245604-22222716-ede3-4c6f-a25b-54e3b1ce8924.png">

En creusant j'ai compris que c'était le widget des pages 404 qui était remplacé par un 0.

**EDIT :** mon diagnostique initial était faux, j'ai mis à jour la PR et mon commentaire.