### PR TITLE
fix(report): Hide disabled tool's widget for a given url

### DIFF
--- a/report/www/src/components/Dashboard.tsx
+++ b/report/www/src/components/Dashboard.tsx
@@ -6,7 +6,7 @@ import { format } from "date-fns";
 
 import { AccessibilityWarnings } from "../lib/lighthouse/AccessibilityWarnings";
 import {
-  isToolEnabled,
+  isToolEnabledGlobally,
   letterGradeValue,
   smallUrl,
   slugifyUrl,
@@ -147,7 +147,7 @@ export const Dashboard: React.FC<DashboardProps> = ({ report }) => {
     },
   ];
 
-  if (isToolEnabled("declaration-a11y")) {
+  if (isToolEnabledGlobally("declaration-a11y")) {
     columns.push(
       getColumn({
         id: "declaration-a11y",
@@ -161,7 +161,7 @@ export const Dashboard: React.FC<DashboardProps> = ({ report }) => {
     );
   }
 
-  if (isToolEnabled("lighthouse")) {
+  if (isToolEnabledGlobally("lighthouse")) {
     columns = columns.concat([
       lightHouseColumn(
         "accessibility",
@@ -181,7 +181,7 @@ export const Dashboard: React.FC<DashboardProps> = ({ report }) => {
     ]);
   }
 
-  if (isToolEnabled("testssl")) {
+  if (isToolEnabledGlobally("testssl")) {
     columns.push(
       getColumn({
         id: "ssl",
@@ -204,7 +204,7 @@ export const Dashboard: React.FC<DashboardProps> = ({ report }) => {
     );
   }
 
-  if (isToolEnabled("http")) {
+  if (isToolEnabledGlobally("http")) {
     columns.push(
       getColumn({
         id: "http",
@@ -217,7 +217,7 @@ export const Dashboard: React.FC<DashboardProps> = ({ report }) => {
     );
   }
 
-  if (isToolEnabled("updownio")) {
+  if (isToolEnabledGlobally("updownio")) {
     columns = columns.concat([
       getColumn({
         id: "updownio",
@@ -240,7 +240,7 @@ export const Dashboard: React.FC<DashboardProps> = ({ report }) => {
     ]);
   }
 
-  if (isToolEnabled("dependabot")) {
+  if (isToolEnabledGlobally("dependabot")) {
     columns.push(
       getColumn({
         id: "dependabot",
@@ -254,7 +254,7 @@ export const Dashboard: React.FC<DashboardProps> = ({ report }) => {
     );
   }
 
-  if (isToolEnabled("codescan")) {
+  if (isToolEnabledGlobally("codescan")) {
     columns.push(
       getColumn({
         id: "codescan",
@@ -268,7 +268,7 @@ export const Dashboard: React.FC<DashboardProps> = ({ report }) => {
     );
   }
 
-  if (isToolEnabled("nmap")) {
+  if (isToolEnabledGlobally("nmap")) {
     columns = columns.concat([
       getColumn({
         id: "nmap",
@@ -290,7 +290,7 @@ export const Dashboard: React.FC<DashboardProps> = ({ report }) => {
     ]);
   }
 
-  if (isToolEnabled("thirdparties")) {
+  if (isToolEnabledGlobally("thirdparties")) {
     columns = columns.concat([
       getColumn({
         id: "trackers",
@@ -319,7 +319,7 @@ export const Dashboard: React.FC<DashboardProps> = ({ report }) => {
     ]);
   }
 
-  if (isToolEnabled("stats")) {
+  if (isToolEnabledGlobally("stats")) {
     columns.push(
       getColumn({
         id: "stats",
@@ -333,7 +333,7 @@ export const Dashboard: React.FC<DashboardProps> = ({ report }) => {
     );
   }
 
-  if (isToolEnabled("404")) {
+  if (isToolEnabledGlobally("404")) {
     columns.push(
       getColumn({
         category: "best-practices",
@@ -349,7 +349,7 @@ export const Dashboard: React.FC<DashboardProps> = ({ report }) => {
     );
   }
 
-  if (isToolEnabled("trivy")) {
+  if (isToolEnabledGlobally("trivy")) {
     columns.push(
       getColumn({
         id: "trivy",

--- a/report/www/src/components/Dashboard.tsx
+++ b/report/www/src/components/Dashboard.tsx
@@ -10,6 +10,7 @@ import {
   letterGradeValue,
   smallUrl,
   slugifyUrl,
+  isToolEnabledForUrl,
 } from "../utils";
 import { Grade } from "./Grade";
 import ColumnHeader from "./ColumnHeader";
@@ -23,32 +24,12 @@ const IconUnknown = () => <Slash size={20} />;
 const percent = (num: number | undefined): string =>
   (num !== undefined && `${Math.floor(num * 100)} %`) || "-";
 
-const GradeBadge = ({
-  grade,
-  label,
-  warning,
-  to,
-}: {
-  grade: string | undefined;
-  label?: string | number | undefined;
-  warning?: string;
-  to?: string;
-}) => (
-  <div style={{ textAlign: "center" }}>
-    {grade ? (
-      <Grade small warning={warning} grade={grade} label={label} to={to} />
-    ) : (
-      <IconUnknown />
-    )}
-  </div>
-);
-
 type GetColumnProps = {
   id: string;
   title: string;
   info: string;
   warning?: JSX.Element | undefined;
-  hash: string;
+  hash: DashlordTool;
   gradeKey: string;
   sort?: Function;
   category?: string;
@@ -89,17 +70,25 @@ export const Dashboard: React.FC<DashboardProps> = ({ report }) => {
     headerRender: () => (
       <ColumnHeader title={title} info={info} warning={warning} />
     ),
-    render: (rowData) => {
-      const { summary } = rowData as UrlReport;
+    render: (rowData: UrlReport) => {
+      const { url, summary } = rowData;
+
       return (
-        <GradeBadge
-          grade={summary[gradeKey]}
-          label={gradeLabel && gradeLabel(summary)}
-          warning={warningText && warningText(summary)}
-          to={`/url/${encodeURIComponent(
-            slugifyUrl((rowData as UrlReport).url)
-          )}/${category ? `${category}/` : ""}#${hash}`}
-        />
+        <div style={{ textAlign: "center" }}>
+          {isToolEnabledForUrl(url, hash) && summary[gradeKey] ? (
+            <Grade
+              small
+              warning={warningText && warningText(summary)}
+              grade={summary[gradeKey]}
+              label={gradeLabel && gradeLabel(summary)}
+              to={`/url/${encodeURIComponent(slugifyUrl(url))}/${
+                category ? `${category}/` : ""
+              }#${hash}`}
+            />
+          ) : (
+            <IconUnknown />
+          )}
+        </div>
       );
     },
   });

--- a/report/www/src/components/Intro.tsx
+++ b/report/www/src/components/Intro.tsx
@@ -10,7 +10,7 @@ import {
 
 import Link from "next/link";
 
-import { isToolEnabled } from "../utils";
+import { isToolEnabledGlobally } from "../utils";
 
 import { Panel } from "./Panel";
 
@@ -57,7 +57,7 @@ export const Intro: React.FC = () => (
       </Button>
     </Callout>
 
-    {isToolEnabled("lighthouse") && (
+    {isToolEnabledGlobally("lighthouse") && (
       <Panel
         title="Google Lighthouse"
         url="https://developers.google.com/web/tools/lighthouse"
@@ -102,7 +102,7 @@ export const Intro: React.FC = () => (
       </Panel>
     )}
 
-    {isToolEnabled("dependabot") && (
+    {isToolEnabledGlobally("dependabot") && (
       <Panel
         title="Dependabot"
         url="https://dependabot.com/"
@@ -129,7 +129,7 @@ export const Intro: React.FC = () => (
       </Panel>
     )}
 
-    {isToolEnabled("codescan") && (
+    {isToolEnabledGlobally("codescan") && (
       <Panel
         title="Codescan"
         urlText="Documentation"
@@ -159,7 +159,7 @@ export const Intro: React.FC = () => (
       </Panel>
     )}
 
-    {isToolEnabled("nmap") && (
+    {isToolEnabledGlobally("nmap") && (
       <Panel
         title="Nmap"
         urlText="Site officiel"
@@ -180,7 +180,7 @@ export const Intro: React.FC = () => (
       </Panel>
     )}
 
-    {isToolEnabled("zap") && (
+    {isToolEnabledGlobally("zap") && (
       <Panel
         title="OWASP Zed Attack Proxy"
         urlText="Site officiel"
@@ -202,7 +202,7 @@ export const Intro: React.FC = () => (
       </Panel>
     )}
 
-    {isToolEnabled("testssl") && (
+    {isToolEnabledGlobally("testssl") && (
       <Panel
         title="testssl.sh"
         urlText="Site officiel"
@@ -234,7 +234,7 @@ export const Intro: React.FC = () => (
       </Panel>
     )}
 
-    {isToolEnabled("http") && (
+    {isToolEnabledGlobally("http") && (
       <Panel
         title="Mozilla HTTP observatory"
         urlText="Site officiel"
@@ -259,7 +259,7 @@ export const Intro: React.FC = () => (
       </Panel>
     )}
 
-    {isToolEnabled("updownio") && (
+    {isToolEnabledGlobally("updownio") && (
       <Panel
         title="Updown.io"
         urlText="Site officiel"
@@ -291,7 +291,7 @@ export const Intro: React.FC = () => (
       </Panel>
     )}
 
-    {isToolEnabled("nuclei") && (
+    {isToolEnabledGlobally("nuclei") && (
       <Panel
         title="Nucléi"
         urlText="Site officiel"
@@ -307,7 +307,7 @@ export const Intro: React.FC = () => (
       </Panel>
     )}
 
-    {isToolEnabled("thirdparties") && (
+    {isToolEnabledGlobally("thirdparties") && (
       <Panel
         title="Third-parties"
         urlText="Code source"
@@ -330,7 +330,7 @@ export const Intro: React.FC = () => (
       </Panel>
     )}
 
-    {isToolEnabled("thirdparties") && (
+    {isToolEnabledGlobally("thirdparties") && (
       <Panel
         title="GeoIP2"
         urlText="Site officiel"
@@ -345,7 +345,7 @@ export const Intro: React.FC = () => (
       </Panel>
     )}
 
-    {isToolEnabled("wappalyzer") && (
+    {isToolEnabledGlobally("wappalyzer") && (
       <Panel
         title="Wappalyzer"
         urlText="Site officiel"
@@ -362,7 +362,7 @@ export const Intro: React.FC = () => (
       </Panel>
     )}
 
-    {isToolEnabled("stats") && (
+    {isToolEnabledGlobally("stats") && (
       <Panel title="Statistiques">
         Vérifie si la page /stats existe
         <br />
@@ -378,13 +378,13 @@ export const Intro: React.FC = () => (
       </Panel>
     )}
 
-    {isToolEnabled("404") && (
+    {isToolEnabledGlobally("404") && (
       <Panel title="Erreurs 404">
         Explore le site web et détecte les liens brisés.
       </Panel>
     )}
 
-    {isToolEnabled("trivy") && (
+    {isToolEnabledGlobally("trivy") && (
       <Panel
         title="Vulnérabilités Trivy"
         url="https://aquasecurity.github.io/trivy/"

--- a/report/www/src/components/Url.tsx
+++ b/report/www/src/components/Url.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { Info, Zap, ThumbsUp, Lock } from "react-feather";
 
-import { isToolEnabled, slugifyUrl, btoa } from "../utils";
+import { isToolEnabledForUrl, slugifyUrl, btoa } from "../utils";
 import { HTTP } from "./HTTP";
 import { LightHouse } from "./LightHouse";
 import { Nuclei } from "./Nuclei";
@@ -206,7 +206,7 @@ export const Url: React.FC<UrlDetailProps> = ({ url, report, selectedTab }) => {
             .filter(
               (item) =>
                 !!report[item.reportKey || item.id] &&
-                isToolEnabled(item.id as DashlordTool)
+                isToolEnabledForUrl(url, item.id as DashlordTool)
             )
             .map((item) => (
               <div key={item.id}>

--- a/report/www/src/utils.ts
+++ b/report/www/src/utils.ts
@@ -26,7 +26,7 @@ export const sortByKey = (key: string) => (a: any, b: any) => {
   return 0;
 };
 
-export const isToolEnabled = (name: DashlordTool): boolean => {
+export const isToolEnabledGlobally = (name: DashlordTool): boolean => {
   const dashlordConfig: DashlordConfig = require("./config.json");
   if (!dashlordConfig.tools) return true;
   if (Array.isArray(dashlordConfig.tools)) {
@@ -37,6 +37,20 @@ export const isToolEnabled = (name: DashlordTool): boolean => {
     );
   }
   return dashlordConfig.tools[name] === true;
+};
+
+export const isToolEnabledForUrl = (
+  url: string,
+  name: DashlordTool
+): boolean => {
+  if (!isToolEnabledGlobally(name)) return false;
+
+  const dashlordConfig: DashlordConfig = require("./config.json");
+  const urlConfig = dashlordConfig.urls.find(
+    (urlConfig) => urlConfig.url === url
+  );
+
+  return !urlConfig.tools || urlConfig.tools[name] !== false;
 };
 
 export const letterGradeValue = (grade: string): number =>

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -7,6 +7,7 @@ type UrlConfig = {
   title?: string;
   tags?: string[];
   repositories?: string[];
+  tools?: Record<DashlordTool, boolean>;
 };
 
 type DashlordTool =


### PR DESCRIPTION
Sur l'[API de Trackdéchets](https://dashlord.mte.incubateur.net/dashlord/url/api-trackdechets-beta-gouv-fr/) on a commencé avec la configuration par défaut, avec notamment le report LightHouse qui n'a pas beaucoup de sens pour une API. Nous l'avons maintenant désactivé mais nous avons des données historiques qui s'affichent toujours.

En creusant il semblerait que les widgets ne s'affichent pas si un outil est désactivé complètement mais la configuration faite au niveau de l'URL n'était pas prise en compte. Avec cette PR, la vérification est bien faite au niveau globale puis au niveau de l'URL.