### PR TITLE
fix(dashboard): add some ✔ indicators

### DIFF
--- a/report/www/src/__tests__/__snapshots__/Dashboard.test.js.snap
+++ b/report/www/src/__tests__/__snapshots__/Dashboard.test.js.snap
@@ -1533,7 +1533,7 @@ exports[`Should render full Dashboard 1`] = `
               onClick={[Function]}
               type="button"
             >
-              0
+              ✔
             </button>
           </div>
         </td>
@@ -1567,7 +1567,7 @@ exports[`Should render full Dashboard 1`] = `
               onClick={[Function]}
               type="button"
             >
-              F
+              X
             </button>
           </div>
         </td>
@@ -1736,7 +1736,17 @@ exports[`Should render full Dashboard 1`] = `
               onClick={[Function]}
               type="button"
             >
-              Ⅹ
+              
+              <span
+                style={
+                  Object {
+                    "marginLeft": 5,
+                  }
+                }
+                title="La politique de confidentialité n'a pas été trouvée"
+              >
+                ⚠️
+              </span>
             </button>
           </div>
         </td>
@@ -2004,7 +2014,7 @@ exports[`Should render full Dashboard 1`] = `
               onClick={[Function]}
               type="button"
             >
-              0
+              ✔
             </button>
           </div>
         </td>
@@ -2038,7 +2048,7 @@ exports[`Should render full Dashboard 1`] = `
               onClick={[Function]}
               type="button"
             >
-              A
+              ✔
             </button>
           </div>
         </td>
@@ -2055,7 +2065,7 @@ exports[`Should render full Dashboard 1`] = `
               onClick={[Function]}
               type="button"
             >
-              A+
+              ✔
             </button>
           </div>
         </td>
@@ -2475,7 +2485,7 @@ exports[`Should render full Dashboard 1`] = `
               onClick={[Function]}
               type="button"
             >
-              0
+              ✔
             </button>
           </div>
         </td>
@@ -2509,7 +2519,7 @@ exports[`Should render full Dashboard 1`] = `
               onClick={[Function]}
               type="button"
             >
-              A
+              ✔
             </button>
           </div>
         </td>
@@ -2526,7 +2536,7 @@ exports[`Should render full Dashboard 1`] = `
               onClick={[Function]}
               type="button"
             >
-              A+
+              ✔
             </button>
           </div>
         </td>
@@ -2689,7 +2699,17 @@ exports[`Should render full Dashboard 1`] = `
               onClick={[Function]}
               type="button"
             >
-              Ⅹ
+              
+              <span
+                style={
+                  Object {
+                    "marginLeft": 5,
+                  }
+                }
+                title="La politique de confidentialité n'a pas été trouvée"
+              >
+                ⚠️
+              </span>
             </button>
           </div>
         </td>
@@ -2842,7 +2862,7 @@ exports[`Should render full Dashboard 1`] = `
               onClick={[Function]}
               type="button"
             >
-              0
+              ✔
             </button>
           </div>
         </td>
@@ -2925,7 +2945,7 @@ exports[`Should render full Dashboard 1`] = `
               onClick={[Function]}
               type="button"
             >
-              0
+              ✔
             </button>
           </div>
         </td>
@@ -2959,7 +2979,7 @@ exports[`Should render full Dashboard 1`] = `
               onClick={[Function]}
               type="button"
             >
-              F
+              X
             </button>
           </div>
         </td>
@@ -3119,7 +3139,7 @@ exports[`Should render full Dashboard 1`] = `
                     "marginLeft": 5,
                   }
                 }
-                title="Votre politique de confidentialité est présente mais incomplète. Consultez les détails pour plus d'informations"
+                title="La politique de confidentialité est présente mais incomplète. Consultez les détails pour plus d'informations"
               >
                 ⚠️
               </span>
@@ -3417,7 +3437,7 @@ exports[`Should render full Dashboard 1`] = `
               onClick={[Function]}
               type="button"
             >
-              0
+              ✔
             </button>
           </div>
         </td>
@@ -3434,7 +3454,7 @@ exports[`Should render full Dashboard 1`] = `
               onClick={[Function]}
               type="button"
             >
-              F
+              X
             </button>
           </div>
         </td>
@@ -3451,7 +3471,7 @@ exports[`Should render full Dashboard 1`] = `
               onClick={[Function]}
               type="button"
             >
-              A+
+              ✔
             </button>
           </div>
         </td>
@@ -3586,7 +3606,17 @@ exports[`Should render full Dashboard 1`] = `
               onClick={[Function]}
               type="button"
             >
-              Ⅹ
+              
+              <span
+                style={
+                  Object {
+                    "marginLeft": 5,
+                  }
+                }
+                title="Les mentions légales n'ont pas été détectées"
+              >
+                ⚠️
+              </span>
             </button>
           </div>
         </td>
@@ -3603,7 +3633,17 @@ exports[`Should render full Dashboard 1`] = `
               onClick={[Function]}
               type="button"
             >
-              Ⅹ
+              
+              <span
+                style={
+                  Object {
+                    "marginLeft": 5,
+                  }
+                }
+                title="La politique de confidentialité n'a pas été trouvée"
+              >
+                ⚠️
+              </span>
             </button>
           </div>
         </td>
@@ -3881,7 +3921,7 @@ exports[`Should render full Dashboard 1`] = `
               onClick={[Function]}
               type="button"
             >
-              0
+              ✔
             </button>
           </div>
         </td>
@@ -3915,7 +3955,7 @@ exports[`Should render full Dashboard 1`] = `
               onClick={[Function]}
               type="button"
             >
-              A
+              ✔
             </button>
           </div>
         </td>
@@ -3932,7 +3972,7 @@ exports[`Should render full Dashboard 1`] = `
               onClick={[Function]}
               type="button"
             >
-              A+
+              ✔
             </button>
           </div>
         </td>
@@ -4091,7 +4131,7 @@ exports[`Should render full Dashboard 1`] = `
                     "marginLeft": 5,
                   }
                 }
-                title="Votre politique de confidentialité est présente mais incomplète. Consultez les détails pour plus d'informations"
+                title="La politique de confidentialité est présente mais incomplète. Consultez les détails pour plus d'informations"
               >
                 ⚠️
               </span>
@@ -4396,7 +4436,7 @@ exports[`Should render full Dashboard 1`] = `
               onClick={[Function]}
               type="button"
             >
-              A
+              ✔
             </button>
           </div>
         </td>
@@ -4865,7 +4905,7 @@ exports[`Should render full Dashboard 1`] = `
               onClick={[Function]}
               type="button"
             >
-              0
+              ✔
             </button>
           </div>
         </td>
@@ -4899,7 +4939,7 @@ exports[`Should render full Dashboard 1`] = `
               onClick={[Function]}
               type="button"
             >
-              A
+              ✔
             </button>
           </div>
         </td>
@@ -4916,7 +4956,7 @@ exports[`Should render full Dashboard 1`] = `
               onClick={[Function]}
               type="button"
             >
-              A+
+              ✔
             </button>
           </div>
         </td>
@@ -5232,7 +5272,7 @@ exports[`Should render full Dashboard 1`] = `
               onClick={[Function]}
               type="button"
             >
-              0
+              ✔
             </button>
           </div>
         </td>
@@ -5315,7 +5355,7 @@ exports[`Should render full Dashboard 1`] = `
               onClick={[Function]}
               type="button"
             >
-              0
+              ✔
             </button>
           </div>
         </td>
@@ -5349,7 +5389,7 @@ exports[`Should render full Dashboard 1`] = `
               onClick={[Function]}
               type="button"
             >
-              F
+              X
             </button>
           </div>
         </td>
@@ -5513,7 +5553,17 @@ exports[`Should render full Dashboard 1`] = `
               onClick={[Function]}
               type="button"
             >
-              Ⅹ
+              
+              <span
+                style={
+                  Object {
+                    "marginLeft": 5,
+                  }
+                }
+                title="La politique de confidentialité n'a pas été trouvée"
+              >
+                ⚠️
+              </span>
             </button>
           </div>
         </td>
@@ -5798,7 +5848,7 @@ exports[`Should render full Dashboard 1`] = `
               onClick={[Function]}
               type="button"
             >
-              0
+              ✔
             </button>
           </div>
         </td>
@@ -5815,7 +5865,7 @@ exports[`Should render full Dashboard 1`] = `
               onClick={[Function]}
               type="button"
             >
-              A
+              ✔
             </button>
           </div>
         </td>
@@ -5967,7 +6017,17 @@ exports[`Should render full Dashboard 1`] = `
               onClick={[Function]}
               type="button"
             >
-              Ⅹ
+              
+              <span
+                style={
+                  Object {
+                    "marginLeft": 5,
+                  }
+                }
+                title="Les mentions légales n'ont pas été détectées"
+              >
+                ⚠️
+              </span>
             </button>
           </div>
         </td>
@@ -5984,7 +6044,17 @@ exports[`Should render full Dashboard 1`] = `
               onClick={[Function]}
               type="button"
             >
-              Ⅹ
+              
+              <span
+                style={
+                  Object {
+                    "marginLeft": 5,
+                  }
+                }
+                title="La politique de confidentialité n'a pas été trouvée"
+              >
+                ⚠️
+              </span>
             </button>
           </div>
         </td>
@@ -6268,7 +6338,7 @@ exports[`Should render full Dashboard 1`] = `
               onClick={[Function]}
               type="button"
             >
-              0
+              ✔
             </button>
           </div>
         </td>
@@ -6285,7 +6355,7 @@ exports[`Should render full Dashboard 1`] = `
               onClick={[Function]}
               type="button"
             >
-              0
+              ✔
             </button>
           </div>
         </td>
@@ -6302,7 +6372,7 @@ exports[`Should render full Dashboard 1`] = `
               onClick={[Function]}
               type="button"
             >
-              A
+              ✔
             </button>
           </div>
         </td>
@@ -6319,7 +6389,7 @@ exports[`Should render full Dashboard 1`] = `
               onClick={[Function]}
               type="button"
             >
-              A+
+              ✔
             </button>
           </div>
         </td>
@@ -6472,7 +6542,7 @@ exports[`Should render full Dashboard 1`] = `
                     "marginLeft": 5,
                   }
                 }
-                title="Vos mentions légales sont présentes mais incomplètes. Consultez les détails pour plus d'informations"
+                title="Les mentions légales sont présentes mais incomplètes. Consultez les détails pour plus d'informations"
               >
                 ⚠️
               </span>
@@ -6499,7 +6569,7 @@ exports[`Should render full Dashboard 1`] = `
                     "marginLeft": 5,
                   }
                 }
-                title="Votre politique de confidentialité est présente mais incomplète. Consultez les détails pour plus d'informations"
+                title="La politique de confidentialité est présente mais incomplète. Consultez les détails pour plus d'informations"
               >
                 ⚠️
               </span>
@@ -6804,7 +6874,7 @@ exports[`Should render full Dashboard 1`] = `
               onClick={[Function]}
               type="button"
             >
-              A
+              ✔
             </button>
           </div>
         </td>
@@ -6821,7 +6891,7 @@ exports[`Should render full Dashboard 1`] = `
               onClick={[Function]}
               type="button"
             >
-              A+
+              ✔
             </button>
           </div>
         </td>

--- a/report/www/src/components/Dashboard.tsx
+++ b/report/www/src/components/Dashboard.tsx
@@ -465,7 +465,6 @@ export const Dashboard: React.FC<DashboardProps> = ({ report }) => {
         hash: "stats",
         gradeKey: "statsGrade",
         gradeLabel: (rowData) => {
-          const grade = rowData.summary.statsGrade;
           if (rowData.summary.statsGrade === "A") {
             return "✔";
           }

--- a/report/www/src/components/Dashboard.tsx
+++ b/report/www/src/components/Dashboard.tsx
@@ -214,6 +214,14 @@ export const Dashboard: React.FC<DashboardProps> = ({ report }) => {
         hash: "github_repository",
         category: "best-practices",
         gradeKey: "githubRepositoryGrade",
+        gradeLabel: (rowData) => {
+          //@ts-ignore
+          const count = rowData.summary.githubRepositoryGrade;
+          if (count === "A") {
+            return "✔";
+          }
+          return count;
+        },
       })
     );
   }
@@ -234,12 +242,14 @@ export const Dashboard: React.FC<DashboardProps> = ({ report }) => {
             case "D":
               return "";
             case "F":
-              return "Ⅹ";
+              return "";
           }
         },
         warningText: (summary) =>
-          summary["declaration-rgpd-ml"] === "D" &&
-          "Vos mentions légales sont présentes mais incomplètes. Consultez les détails pour plus d'informations",
+          (summary["declaration-rgpd-ml"] === "D" &&
+            "Les mentions légales sont présentes mais incomplètes. Consultez les détails pour plus d'informations") ||
+          (summary["declaration-rgpd-ml"] === "F" &&
+            "Les mentions légales n'ont pas été détectées"),
       })
     );
     columns.push(
@@ -257,12 +267,14 @@ export const Dashboard: React.FC<DashboardProps> = ({ report }) => {
             case "D":
               return "";
             case "F":
-              return "Ⅹ";
+              return "";
           }
         },
         warningText: (summary) =>
-          summary["declaration-rgpd-pc"] === "D" &&
-          "Votre politique de confidentialité est présente mais incomplète. Consultez les détails pour plus d'informations",
+          (summary["declaration-rgpd-pc"] === "D" &&
+            "La politique de confidentialité est présente mais incomplète. Consultez les détails pour plus d'informations") ||
+          (summary["declaration-rgpd-pc"] === "F" &&
+            "La politique de confidentialité n'a pas été trouvée"),
       })
     );
   }
@@ -369,7 +381,13 @@ export const Dashboard: React.FC<DashboardProps> = ({ report }) => {
         category: "securite",
         hash: "codescan",
         gradeKey: "codescanGrade",
-        gradeLabel: (rowData) => rowData.summary.codescanCount,
+        gradeLabel: (rowData) => {
+          const count = rowData.summary.codescanCount;
+          if (count === 0) {
+            return "✔";
+          }
+          return count;
+        },
       })
     );
   }
@@ -411,7 +429,13 @@ export const Dashboard: React.FC<DashboardProps> = ({ report }) => {
         category: "best-practices",
         hash: "thirdparties",
         gradeKey: "trackersGrade",
-        gradeLabel: (rowData) => rowData.summary.trackersCount,
+        gradeLabel: (rowData) => {
+          const count = rowData.summary.trackersCount;
+          if (count === 0) {
+            return "✔";
+          }
+          return count;
+        },
       }),
       getColumn({
         id: "cookies",
@@ -420,7 +444,13 @@ export const Dashboard: React.FC<DashboardProps> = ({ report }) => {
         category: "best-practices",
         hash: "thirdparties",
         gradeKey: "cookiesGrade",
-        gradeLabel: (rowData) => rowData.summary.cookiesCount,
+        gradeLabel: (rowData) => {
+          const count = rowData.summary.cookiesCount;
+          if (count === 0) {
+            return "✔";
+          }
+          return count;
+        },
       }),
     ]);
   }
@@ -434,7 +464,13 @@ export const Dashboard: React.FC<DashboardProps> = ({ report }) => {
         info: "Présence de la page des statistiques",
         hash: "stats",
         gradeKey: "statsGrade",
-        gradeLabel: (rowData) => rowData.summary.statsCount,
+        gradeLabel: (rowData) => {
+          const grade = rowData.summary.statsGrade;
+          if (rowData.summary.statsGrade === "A") {
+            return "✔";
+          }
+          return "X";
+        },
       })
     );
   }
@@ -462,7 +498,12 @@ export const Dashboard: React.FC<DashboardProps> = ({ report }) => {
         hash: "404",
         gradeKey: "404",
         gradeLabel: (rowData) => {
-          return rowData.summary["404"];
+          const count = rowData.summary["404"];
+          //@ts-ignore
+          if (count === 0 || count === "A+") {
+            return "✔";
+          }
+          return count;
         },
       })
     );


### PR DESCRIPTION
Affiche plus de `✔ ` lorsque le score est OK pour : trackers, repo github, rgpd, stats

<img width="1476" alt="Capture d’écran 2022-05-23 à 09 25 54" src="https://user-images.githubusercontent.com/124937/169765977-b650961f-340c-4517-96fd-4a9369168e88.png">

