### PR TITLE
Use configuration to use a custom logo and css in the report

### DIFF
--- a/report/www/pages/_app.tsx
+++ b/report/www/pages/_app.tsx
@@ -32,7 +32,10 @@ function MyApp({ Component, pageProps }: AppProps) {
     init({ url: MATOMO_URL, siteId: "" + MATOMO_SITE_ID });
   }, []);
   return (
-    <div className={(dashlordConfig.marianne ? "" : "nonGovernementalWebsite")}>
+    <div className={(dashlordConfig.marianne ? "" : "non-governemental-website")}>
+      { dashlordConfig.customCss &&
+        <link rel="stylesheet" type="text/css" href={dashlordConfig.customCss}/>
+      }
       <Head>
         <meta charSet="utf-8" lang="FR-fr" />
         <meta

--- a/report/www/src/components/HeaderSite.tsx
+++ b/report/www/src/components/HeaderSite.tsx
@@ -57,6 +57,23 @@ const TitleLink = ({
   );
 };
 
+const CustomHeader = () => <div className="custom-header">
+  <img src={dashlordConfig.logo} alt={dashlordConfig.logoAltTxt}/>
+  <div className="custom-title">
+    <h1>{dashlordConfig.title}</h1>
+    <p>{dashlordConfig.description}</p>
+  </div>
+</div>
+
+const MarianneHeader = () => <div>
+  <Marianne asLink={<TitleLink href="/"/>} splitCharacter={10}>{dashlordConfig.entity}</Marianne>
+  <Service
+    asLink={<TitleLink href="/" />}
+    title={dashlordConfig.title}
+    description={dashlordConfig.description}
+  />
+</div>
+
 export const HeaderSite: React.FC<HeaderSiteProps> = ({ report }) => {
   const sortedReport = (report && report.sort(sortByKey("url"))) || [];
   const categories = uniq(
@@ -65,19 +82,12 @@ export const HeaderSite: React.FC<HeaderSiteProps> = ({ report }) => {
   const tags = uniq(
     sortedReport.filter((u) => u.category).flatMap((u) => u.tags)
   ).sort() as string[];
-  const Logo = dashlordConfig.marianne ? Marianne : () => <div />;
+  const ConfigHeader = dashlordConfig.marianne ? MarianneHeader : CustomHeader;
   return (
     <>
       <Header>
         <HeaderBody>
-          <Logo asLink={<TitleLink href="/" />} splitCharacter={10}>
-            {dashlordConfig.entity}
-          </Logo>
-          <Service
-            asLink={<TitleLink href="/" />}
-            title={dashlordConfig.title}
-            description={dashlordConfig.description}
-          />
+          <ConfigHeader/>
           <Tool closeButtonLabel="fermer">
             <ToolItemGroup>
               {dashlordConfig.loginUrl && (

--- a/report/www/src/overrideDSFR.css
+++ b/report/www/src/overrideDSFR.css
@@ -5,7 +5,26 @@
 
   }
 
-.nonGovernementalWebsite {
+.custom-header {
+    display: flex;
+    img {
+        max-width: 200px;
+        max-height: 150px;
+    }
+    
+    .custom-title {
+        margin: 0 50px;
+        h1 {
+            font-size: 25px;
+        }
+    }
+
+    .fr-header__brand {
+        display: none;
+    }
+}
+
+.non-governemental-website {
     /* most crucial change, remove use of the Marianne protected font */
     font-family: Helvetica, Arial, sans-serif;
 
@@ -40,6 +59,6 @@
         background-color:var(--background-default-green-non-france);
         color:var(--text-action-high-grey);
         font-weight: bold;
-      }
+    }
 }
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -45,6 +45,9 @@ type DashlordConfig = {
   tools?: DashlordTool[] | Record<DashlordTool, boolean>;
   urls: UrlConfig[];
   marianne?: boolean;
+  logo?: string;
+  logoAltTxt?: string;
+  customCss?: string;
   loginUrl?: string;
   matomoId?: number;
   matomoUrl?: string;


### PR DESCRIPTION
I added three parameters to the dashlord yml : 
- logo: url of the logo
- logoAltTxt: alt text for the logo
- customCss: url of the css (note the css file needs to be hosted to be recognised as mime type css, I added the necessary information to the dashlord-template readme

Note, I tried but it didn't seem easily possible to simply include the logo in the existing header (it did gave me the opportunity to play around with the dsfr-react repo) so I just replaced it in the end