### PR TITLE
Update index.js

### DIFF
--- a/declaration-rgpd/index.js
+++ b/declaration-rgpd/index.js
@@ -22,6 +22,7 @@ const searches = [
       "Politique de confidentialité",
       "Privacy Policy",
       "Données personnelles",
+      "Mentions d'information",
     ],
     mustMatch: [
       ["@"],


### PR DESCRIPTION
Nos tutelles nous ont obligés à donner comme titre à notre politique de confidentialité : "Mentions d'information" (cf ici : https://conseillers-entreprises.service-public.fr/mentions_d_information). Et donc, dashlord la trouve pas.