### PR TITLE
chore(report): update Mozilla Observatory url

### DIFF
--- a/report/www/src/components/HTTP.tsx
+++ b/report/www/src/components/HTTP.tsx
@@ -150,7 +150,7 @@ export const HTTP = ({ data }: HTTPProps) => {
   }
   const url =
     (data &&
-      `https://observatory.mozilla.org/analyze/${smallUrl(
+      `https://developer.mozilla.org/fr/observatory/analyze?host=${smallUrl(
         data.url.replace(/^(https?:\/\/[^/]+).*/, "$1")
       )}`) ||
     null;

--- a/report/www/src/tools.json
+++ b/report/www/src/tools.json
@@ -64,7 +64,7 @@
   },
   "http": {
     "label": "Mozilla HTTP observatory",
-    "url": "https://observatory.mozilla.org/",
+    "url": "https://developer.mozilla.org/fr/observatory",
     "tags": [
       "security"
     ],

--- a/report/www/src/tools.yaml
+++ b/report/www/src/tools.yaml
@@ -97,7 +97,7 @@ testssl:
 
 http:
   label: Mozilla HTTP observatory
-  url: https://observatory.mozilla.org/
+  url: https://developer.mozilla.org/fr/observatory
   tags:
     - security
   description: |


### PR DESCRIPTION
[Mozilla observatory](https://observatory.mozilla.org/) is now deprecated ([annoucement](https://developer.mozilla.org/en-US/blog/mdn-http-observatory-launch/)).

This PR only changes the URL, and does not rename "Mozilla observatory" to "MDN HTTP observatory", should it be done ? 