### PR TITLE
feat: add init from txt

### DIFF
--- a/.github/test_urls.txt
+++ b/.github/test_urls.txt
@@ -1,0 +1,9 @@
+https://row1.com
+https://row2.com
+https://row3.com
+https://row4.com
+https://row5.com
+https://row6.com
+https://row7.com
+https://row8.com
+https://row9.com

--- a/.github/workflows/init-from-txt.yml
+++ b/.github/workflows/init-from-txt.yml
@@ -2,12 +2,12 @@ on:
   push:
     branches: ["*"]
     paths:
-      - init/**
+      - init-from-txt/**
       - .github/workflows/init-from-txt.yml
   pull_request:
     branches: ["*"]
     paths:
-      - init/**
+      - init-from-txt/**
       - .github/workflows/init-from-txt.yml
   workflow_dispatch:
     inputs:

--- a/.github/workflows/init-from-txt.yml
+++ b/.github/workflows/init-from-txt.yml
@@ -31,6 +31,8 @@ jobs:
           cd init
       - id: init
         uses: "./init-from-txt"
+        with:
+          txtPath: ".github/test_urls.txt"
       - id: test
         run: |
           EXPECTED="[{url:https://www.free.fr,title:Free,repositories:[iliad/free-ui,iliad/free-api],tools:{screenshot:true,nmap:true,zap:true,wappalyzer:true,http:true,testssl:true,lighthouse:true,thirdparties:true,nuclei:true,updownio:true,dependabot:true,codescan:true,stats:true,budget_page:true,declaration-a11y:true,declaration-rgpd:true,betagouv:true},subpages:[https://www.free.fr]},{url:http://chez.com,repositories:[chez/chez-ui,chez/chez-api],pages:[/login,/profile],tools:{screenshot:false,nmap:true,zap:true,wappalyzer:true,http:true,testssl:true,lighthouse:true,thirdparties:true,nuclei:true,updownio:false,dependabot:true,codescan:true,stats:false,budget_page:true,declaration-a11y:true,declaration-rgpd:true,betagouv:true},subpages:[http://chez.com,http://chez.com/login,http://chez.com/profile]},{url:https://voila.fr,tools:{screenshot:true,nmap:true,zap:true,wappalyzer:true,http:true,testssl:true,lighthouse:true,thirdparties:true,nuclei:true,updownio:true,dependabot:true,codescan:true,stats:true,budget_page:true,declaration-a11y:true,declaration-rgpd:true,betagouv:true},subpages:[https://voila.fr]}]"

--- a/.github/workflows/init-from-txt.yml
+++ b/.github/workflows/init-from-txt.yml
@@ -27,19 +27,16 @@ jobs:
       config: ${{ steps.init.outputs.config }}
     steps:
       - uses: actions/checkout@v4
-      - run: |
-          cd init
       - id: init
         uses: "./init-from-txt"
         with:
           txtPath: ".github/test_urls.txt"
       - id: test
         run: |
-          echo "${{ steps.init.outputs.sites }}"
-          # EXPECTED="[{url:https://www.free.fr,title:Free,repositories:[iliad/free-ui,iliad/free-api],tools:{screenshot:true,nmap:true,zap:true,wappalyzer:true,http:true,testssl:true,lighthouse:true,thirdparties:true,nuclei:true,updownio:true,dependabot:true,codescan:true,stats:true,budget_page:true,declaration-a11y:true,declaration-rgpd:true,betagouv:true},subpages:[https://www.free.fr]},{url:http://chez.com,repositories:[chez/chez-ui,chez/chez-api],pages:[/login,/profile],tools:{screenshot:false,nmap:true,zap:true,wappalyzer:true,http:true,testssl:true,lighthouse:true,thirdparties:true,nuclei:true,updownio:false,dependabot:true,codescan:true,stats:false,budget_page:true,declaration-a11y:true,declaration-rgpd:true,betagouv:true},subpages:[http://chez.com,http://chez.com/login,http://chez.com/profile]},{url:https://voila.fr,tools:{screenshot:true,nmap:true,zap:true,wappalyzer:true,http:true,testssl:true,lighthouse:true,thirdparties:true,nuclei:true,updownio:true,dependabot:true,codescan:true,stats:true,budget_page:true,declaration-a11y:true,declaration-rgpd:true,betagouv:true},subpages:[https://voila.fr]}]"
-          # RESULT="${{ steps.init.outputs.sites }}"
-          # echo "RESULT=$RESULT"
-          # [[ "$EXPECTED" == "$RESULT" ]]
+          EXPECTED="[{url: https://row1.com}, {url: https://row2.com}, {url: https://row3.com}, {url: https://row4.com}, {url: https://row5.com}, {url: https://row6.com}, {url: https://row7.com}, {url: https://row8.com}, {url: https://row9.com}]"
+          RESULT="${{ steps.init.outputs.sites }}"
+          echo "RESULT=$RESULT"
+          [[ "$EXPECTED" == "$RESULT" ]]
 
   scans:
     runs-on: ubuntu-latest

--- a/.github/workflows/init-from-txt.yml
+++ b/.github/workflows/init-from-txt.yml
@@ -22,9 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Prepare full scan
     outputs:
-      urls: ${{ steps.init.outputs.urls }}
       sites: ${{ steps.init.outputs.sites }}
-      config: ${{ steps.init.outputs.config }}
     steps:
       - uses: actions/checkout@v4
       - id: init

--- a/.github/workflows/init-from-txt.yml
+++ b/.github/workflows/init-from-txt.yml
@@ -35,10 +35,11 @@ jobs:
           txtPath: ".github/test_urls.txt"
       - id: test
         run: |
-          EXPECTED="[{url:https://www.free.fr,title:Free,repositories:[iliad/free-ui,iliad/free-api],tools:{screenshot:true,nmap:true,zap:true,wappalyzer:true,http:true,testssl:true,lighthouse:true,thirdparties:true,nuclei:true,updownio:true,dependabot:true,codescan:true,stats:true,budget_page:true,declaration-a11y:true,declaration-rgpd:true,betagouv:true},subpages:[https://www.free.fr]},{url:http://chez.com,repositories:[chez/chez-ui,chez/chez-api],pages:[/login,/profile],tools:{screenshot:false,nmap:true,zap:true,wappalyzer:true,http:true,testssl:true,lighthouse:true,thirdparties:true,nuclei:true,updownio:false,dependabot:true,codescan:true,stats:false,budget_page:true,declaration-a11y:true,declaration-rgpd:true,betagouv:true},subpages:[http://chez.com,http://chez.com/login,http://chez.com/profile]},{url:https://voila.fr,tools:{screenshot:true,nmap:true,zap:true,wappalyzer:true,http:true,testssl:true,lighthouse:true,thirdparties:true,nuclei:true,updownio:true,dependabot:true,codescan:true,stats:true,budget_page:true,declaration-a11y:true,declaration-rgpd:true,betagouv:true},subpages:[https://voila.fr]}]"
-          RESULT="${{ steps.init.outputs.sites }}"
-          echo "RESULT=$RESULT"
-          [[ "$EXPECTED" == "$RESULT" ]]
+          echo "${{ steps.init.outputs.sites }}"
+          # EXPECTED="[{url:https://www.free.fr,title:Free,repositories:[iliad/free-ui,iliad/free-api],tools:{screenshot:true,nmap:true,zap:true,wappalyzer:true,http:true,testssl:true,lighthouse:true,thirdparties:true,nuclei:true,updownio:true,dependabot:true,codescan:true,stats:true,budget_page:true,declaration-a11y:true,declaration-rgpd:true,betagouv:true},subpages:[https://www.free.fr]},{url:http://chez.com,repositories:[chez/chez-ui,chez/chez-api],pages:[/login,/profile],tools:{screenshot:false,nmap:true,zap:true,wappalyzer:true,http:true,testssl:true,lighthouse:true,thirdparties:true,nuclei:true,updownio:false,dependabot:true,codescan:true,stats:false,budget_page:true,declaration-a11y:true,declaration-rgpd:true,betagouv:true},subpages:[http://chez.com,http://chez.com/login,http://chez.com/profile]},{url:https://voila.fr,tools:{screenshot:true,nmap:true,zap:true,wappalyzer:true,http:true,testssl:true,lighthouse:true,thirdparties:true,nuclei:true,updownio:true,dependabot:true,codescan:true,stats:true,budget_page:true,declaration-a11y:true,declaration-rgpd:true,betagouv:true},subpages:[https://voila.fr]}]"
+          # RESULT="${{ steps.init.outputs.sites }}"
+          # echo "RESULT=$RESULT"
+          # [[ "$EXPECTED" == "$RESULT" ]]
 
   scans:
     runs-on: ubuntu-latest

--- a/.github/workflows/init-from-txt.yml
+++ b/.github/workflows/init-from-txt.yml
@@ -1,0 +1,53 @@
+on:
+  push:
+    branches: ["*"]
+    paths:
+      - init/**
+      - .github/workflows/init-from-txt.yml
+  pull_request:
+    branches: ["*"]
+    paths:
+      - init/**
+      - .github/workflows/init-from-txt.yml
+  workflow_dispatch:
+    inputs:
+      url:
+        description: "Single url to scan or scan all urls"
+        required: false
+        default: ""
+
+name: Test init matrix from txt
+jobs:
+  test1:
+    runs-on: ubuntu-latest
+    name: Prepare full scan
+    outputs:
+      urls: ${{ steps.init.outputs.urls }}
+      sites: ${{ steps.init.outputs.sites }}
+      config: ${{ steps.init.outputs.config }}
+    steps:
+      - uses: actions/checkout@v4
+      - run: |
+          cd init
+      - id: init
+        uses: "./init-from-txt"
+      - id: test
+        run: |
+          EXPECTED="[{url:https://www.free.fr,title:Free,repositories:[iliad/free-ui,iliad/free-api],tools:{screenshot:true,nmap:true,zap:true,wappalyzer:true,http:true,testssl:true,lighthouse:true,thirdparties:true,nuclei:true,updownio:true,dependabot:true,codescan:true,stats:true,budget_page:true,declaration-a11y:true,declaration-rgpd:true,betagouv:true},subpages:[https://www.free.fr]},{url:http://chez.com,repositories:[chez/chez-ui,chez/chez-api],pages:[/login,/profile],tools:{screenshot:false,nmap:true,zap:true,wappalyzer:true,http:true,testssl:true,lighthouse:true,thirdparties:true,nuclei:true,updownio:false,dependabot:true,codescan:true,stats:false,budget_page:true,declaration-a11y:true,declaration-rgpd:true,betagouv:true},subpages:[http://chez.com,http://chez.com/login,http://chez.com/profile]},{url:https://voila.fr,tools:{screenshot:true,nmap:true,zap:true,wappalyzer:true,http:true,testssl:true,lighthouse:true,thirdparties:true,nuclei:true,updownio:true,dependabot:true,codescan:true,stats:true,budget_page:true,declaration-a11y:true,declaration-rgpd:true,betagouv:true},subpages:[https://voila.fr]}]"
+          RESULT="${{ steps.init.outputs.sites }}"
+          echo "RESULT=$RESULT"
+          [[ "$EXPECTED" == "$RESULT" ]]
+
+  scans:
+    runs-on: ubuntu-latest
+    name: Scan
+    needs: test1
+    continue-on-error: true
+    strategy:
+      fail-fast: false
+      max-parallel: 3
+      matrix:
+        sites: ${{ fromJson(needs.test1.outputs.sites) }}
+    steps:
+      - run: |
+          echo "${{ matrix.sites.url }}"

--- a/init-from-txt/action.yml
+++ b/init-from-txt/action.yml
@@ -9,7 +9,7 @@ inputs:
     description: "Max number of URLs to return"
     required: false
     default: "10"
-  txtFile:
+  txtPath:
     description: "Path to the txt urls list file"
     required: false
     default: "urls.txt"
@@ -35,7 +35,7 @@ runs:
       id: init
       env:
         CACHE_PATH: ${{ inputs.cachePath || './results' }}
-        TXT_PATH: "urls.txt"
+        TXT_PATH: ${{ inputs.txtPath || 'urls.txt' }}
         MATRIX_MAX_COUNT: ${{ inputs.count || 10 }}
       run: |
         # Create a Python script to process URLs

--- a/init-from-txt/action.yml
+++ b/init-from-txt/action.yml
@@ -92,5 +92,3 @@ runs:
 
         # todo: handle single url
         python process_urls.py ${{ env.MATRIX_MAX_COUNT }}
-
-        env

--- a/init-from-txt/action.yml
+++ b/init-from-txt/action.yml
@@ -1,0 +1,96 @@
+name: "DashLord init action"
+description: "Parse dashlord txt config files and return some urls to scan"
+inputs:
+  cachePath:
+    description: "Where urls results are stored"
+    required: false
+    default: "./results"
+  count:
+    description: "Max number of URLs to return"
+    required: false
+    default: "10"
+  txtFile:
+    description: "Path to the txt urls list file"
+    required: false
+    default: "urls.txt"
+outputs:
+  sites:
+    description: List of urls to scan as plain text
+    value: ${{ steps.init.outputs.sites }}
+
+runs:
+  using: composite
+  steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.x"
+
+    - name: Process URL list
+      shell: bash
+      id: init
+      env:
+        CACHE_PATH: ${{ inputs.cachePath || './results' }}
+        TXT_PATH: "urls.txt"
+        MATRIX_MAX_COUNT: ${{ inputs.count || 10 }}
+      run: |
+        # Create a Python script to process URLs
+        cat << 'EOF' > process_urls.py
+        import os
+        import base64
+        import json
+        import sys
+        import subprocess
+        from datetime import datetime
+
+        def get_b64_path(url):
+            return os.path.join(os.environ.get("CACHE_PATH"), base64.b64encode(url.encode()).decode())
+
+        def get_git_last_modified(path):
+            try:
+                # Get the last commit date for the file
+                result = subprocess.run(
+                    ['git', 'log', '-1', '--format=%at', '--', path],
+                    capture_output=True,
+                    text=True
+                )
+                print(result)
+                if result.stdout.strip():
+                    return float(result.stdout.strip())
+                return float('-inf')  # File doesn't exist in git history
+            except Exception:
+                print("error")
+                return float('-inf')  # Error running git command
+
+
+        # Read URLs from file
+        with open(os.environ.get("TXT_PATH"), 'r') as f:
+            urls = [line.strip() for line in f if line.strip()]
+
+        # Sort URLs based on existence and modification time
+        sorted_urls = sorted(
+            urls,
+            key=lambda url: (
+                os.path.exists(get_b64_path(url)),
+                get_git_last_modified(get_b64_path(url))
+            )
+        )
+
+        # Take only the first N URLs (from input)
+        matrix_count = int(sys.argv[1])
+        matrix_urls = sorted_urls[:matrix_count]
+
+        # Output the matrix JSON to GITHUB_OUTPUT
+        urls_json = json.dumps([{"url": url} for url in matrix_urls])
+        with open(os.environ['GITHUB_OUTPUT'], 'a') as fh:
+            fh.write(f"sites={urls_json}")
+        EOF
+
+        # todo: handle single url
+        python process_urls.py ${{ env.MATRIX_MAX_COUNT }}
+
+        env

--- a/init-from-txt/action.yml
+++ b/init-from-txt/action.yml
@@ -35,7 +35,7 @@ runs:
       id: init
       env:
         CACHE_PATH: ${{ inputs.cachePath || './results' }}
-        TXT_PATH: ${{ inputs.txtPath || 'urls.txt' }}
+        TXT_PATH: ${{ inputs.txtPath || 'xxx.txt' }}
         MATRIX_MAX_COUNT: ${{ inputs.count || 10 }}
       run: |
         # Create a Python script to process URLs


### PR DESCRIPTION
allow to load a list of urls from an urls.txt

Example usage:

```yaml
name: URLs matrix
jobs:
  init:
    runs-on: ubuntu-latest
    name: Prepare full scan
    outputs:
      sites: ${{ steps.init.outputs.sites }}
    steps:
      - uses: actions/checkout@v4
      - id: init
        uses: "SocialGouv/dashlord-actions/init-from-txt@v1"
        with: 
          count: 100
  scans:
    runs-on: ubuntu-latest
    name: Scan
    needs: init
    continue-on-error: true
    strategy:
      fail-fast: false
      max-parallel: 3
      matrix:
        sites: ${{ fromJson(needs.test1.outputs.sites) }}
    steps:
      - run: |
          echo "${{ matrix.sites.url }}"

```