### PR TITLE
fix(report): handle unknown beta.gouv phases & add 'consolidation'

### DIFF
--- a/report/www/src/components/BetagouvInfo.tsx
+++ b/report/www/src/components/BetagouvInfo.tsx
@@ -5,6 +5,7 @@ import {
 } from "react-vertical-timeline-component";
 import "react-vertical-timeline-component/style.min.css";
 import {
+  Anchor,
   Crosshair,
   FastForward,
   Settings,
@@ -26,12 +27,16 @@ type BetagouvPhase = {
   index: number;
 };
 
+const unknownPhase = { id: "-", label: "-", index: 0 };
+
 // return latest phase augmented data if any
 export const getLatestPhase = (allphases: BetagouvReportPhase[]) => {
   const sortedPhases = allphases.sort(sortPhases);
-  return sortedPhases.length
-    ? getPhase(sortedPhases[sortedPhases.length - 1].name)
-    : { id: "-", label: "-", index: 0 }; // fallback
+  if (!sortedPhases.length) {
+    return unknownPhase; // no phase at all
+  }
+  // the API may return a phase not yet referenced in `phases` below
+  return getPhase(sortedPhases[sortedPhases.length - 1].name) || unknownPhase;
 };
 
 export const Betagouv: React.FC<BetagouvProps> = ({ data }) => {
@@ -41,6 +46,10 @@ export const Betagouv: React.FC<BetagouvProps> = ({ data }) => {
       <VerticalTimeline lineColor="var(--text-action-high-blue-france)">
         {sortedPhases.map((phase) => {
           const phaseData = getPhase(phase.name);
+          if (!phaseData) {
+            // phase not referenced in `phases` yet — skip rather than crash
+            return null;
+          }
           return (
             <VerticalTimelineElement
               key={phase.name}
@@ -111,6 +120,14 @@ export const phases = [
     icon: FastForward,
     index: 3,
   },
+  {
+    id: "consolidation",
+    label: "Consolidation",
+    description:
+      "Aider le service numérique à trouver sa place dans un écosystème plus pérenne (succès en cours).",
+    icon: Anchor,
+    index: 4,
+  },
   { id: "success", label: "Succès", icon: Heart, index: 4 },
   {
     id: "transfer",
@@ -130,6 +147,7 @@ export const phases = [
 
 export const phaseSeverities = {
   accélération: "info",
+  consolidation: "info",
   construction: "warning",
   "partenariat terminé": "error",
   transfert: "success",
@@ -146,10 +164,10 @@ const getPhase = (phase: string) => phases.find((f) => f.id === phase);
 // sort some input phases
 const sortPhases = (a: BetagouvReportPhase, b: BetagouvReportPhase) => {
   if (a.start === b.start) {
-    // order dictated by phases definitions
+    // order dictated by phases definitions ; a phase might not be referenced yet
     return (
-      phases.find((p) => p.id === a.name).index -
-      phases.find((p) => p.id === b.name).index
+      (phases.find((p) => p.id === a.name)?.index ?? 0) -
+      (phases.find((p) => p.id === b.name)?.index ?? 0)
     );
   }
   // order dictated by date


### PR DESCRIPTION
## Problème

Le build du rapport (`report`) plante pendant l'export statique Next.js dès qu'un site possède dans ses données beta.gouv une phase **non référencée** dans la liste `phases` codée en dur de `BetagouvInfo.tsx`.

C'est le cas avec la phase **`consolidation`** désormais renvoyée par l'API beta.gouv.fr (vue sur `agentsenintervention.anct.gouv.fr`). `getPhase("consolidation")` renvoie `undefined`, ce qui casse :

- `/summary/accessibility` (et autres `/summary/*`) → `TypeError: Cannot read properties of undefined (reading 'index')` dans le `valueGetter` de la colonne `phase`
- `/url/<site>/informations` → `TypeError: Cannot read properties of undefined (reading 'icon')` dans la timeline `<phaseData.icon />`

Conséquence : `next export` sort en exit 1, le commit de `report.json` et le déploiement `gh-pages` sont skippés → le dashboard ne se met plus à jour.

## Correctif

1. **Robustesse** — le rendu ne doit plus jamais crasher sur une phase inconnue, même future :
   - `getLatestPhase()` retombe sur un placeholder si la phase n'est pas répertoriée
   - la timeline `Betagouv` ignore une phase inconnue plutôt que de lever une exception
   - `sortPhases()` tolère une phase absente des définitions (`?.index ?? 0`)

2. **Ajout de la phase `consolidation`.** Phase officielle beta.gouv.fr qui suit l'accélération (« le service trouve une structure d'accueil propice à sa pérennité »). Métadonnées d'affichage choisies selon sa sémantique — phase d'ancrage durable, « succès en cours » et non abouti :
   - sévérité **`info`** (et non `success`) : phase active/positive mais pas encore aboutie, cohérent avec `accélération`
   - icône **`Anchor`** : ancrage / enracinement dans un écosystème pérenne

> Note pour les mainteneurs : le label, la description et l'index de `consolidation` peuvent être ajustés si vous disposez d'un libellé de référence côté beta.gouv.fr.

## Test

Reproductible avec une donnée `betagouv.json` contenant `{ "name": "consolidation", "start": "2026-01-01" }`.